### PR TITLE
Allow editing input profiles during emulation

### DIFF
--- a/configdialog.cpp
+++ b/configdialog.cpp
@@ -78,17 +78,6 @@ void ProfileTab::setComboBox(QComboBox* box, ControllerTab **_controllerTabs)
     box->removeItem(box->findText("Auto-Keyboard"));
 }
 
-int ProfileTab::checkNotRunning()
-{
-    if (emu_running) {
-        QMessageBox msgBox;
-        msgBox.setText("Stop game before editing profiles.");
-        msgBox.exec();
-        return 0;
-    }
-    return 1;
-}
-
 ProfileTab::ProfileTab(ControllerTab **_controllerTabs)
 {
     QGridLayout *layout = new QGridLayout(this);
@@ -96,23 +85,19 @@ ProfileTab::ProfileTab(ControllerTab **_controllerTabs)
     setComboBox(profileSelect, _controllerTabs);
     QPushButton *buttonNewKeyboard = new QPushButton("New Profile (Keyboard)", this);
     connect(buttonNewKeyboard, &QPushButton::released, [=]() {
-        if (checkNotRunning()) {
-            ProfileEditor editor("Auto-Keyboard");
-            editor.exec();
-            setComboBox(profileSelect, _controllerTabs);
-        }
+        ProfileEditor editor("Auto-Keyboard");
+        editor.exec();
+        setComboBox(profileSelect, _controllerTabs);
     });
     QPushButton *buttonNewGamepad = new QPushButton("New Profile (Gamepad)", this);
     connect(buttonNewGamepad, &QPushButton::released, [=]() {
-        if (checkNotRunning()) {
-            ProfileEditor editor("Auto-Gamepad");
-            editor.exec();
-            setComboBox(profileSelect, _controllerTabs);
-        }
+        ProfileEditor editor("Auto-Gamepad");
+        editor.exec();
+        setComboBox(profileSelect, _controllerTabs);
     });
     QPushButton *buttonEdit = new QPushButton("Edit Profile", this);
     connect(buttonEdit, &QPushButton::released, [=]() {
-        if (!profileSelect->currentText().isEmpty() && checkNotRunning()) {
+        if (!profileSelect->currentText().isEmpty()) {
             ProfileEditor editor(profileSelect->currentText());
             editor.exec();
         }

--- a/configdialog.h
+++ b/configdialog.h
@@ -10,7 +10,6 @@
 
 extern QSettings* settings;
 extern QSettings* controllerSettings;
-extern int emu_running;
 
 class ControllerTab : public QWidget
 {
@@ -43,7 +42,6 @@ class ProfileTab : public QWidget
 public:
     ProfileTab(ControllerTab **_controllerTabs);
 private:
-    int checkNotRunning();
     void setComboBox(QComboBox* box, ControllerTab **_controllerTabs);
 };
 

--- a/main.cpp
+++ b/main.cpp
@@ -38,7 +38,6 @@
 #define QT_INPUT_PLUGIN_VERSION 0x020500
 #define INPUT_PLUGIN_API_VERSION 0x020100
 static int l_PluginInit = 0;
-int emu_running = 0;
 static unsigned char myKeyState[SDL_NUM_SCANCODES];
 QSettings* settings;
 QSettings* controllerSettings;
@@ -196,7 +195,6 @@ void closeControllers()
         controller[i].gamepad = NULL;
         controller[i].joystick = NULL;
     }
-    emu_running = 0;
 }
 
 EXPORT m64p_error CALL PluginShutdown(void)
@@ -569,7 +567,6 @@ EXPORT void CALL InitiateControllers(CONTROL_INFO ControlInfo)
 
         setPak(i);
     }
-    emu_running = 1;
 }
 
 EXPORT void CALL ReadController(int, unsigned char *)


### PR DESCRIPTION
I'm not sure what the rational behind forcing users to end emulation before adjusting their input profiles is, but I always found it to be a cumbersome feature. Allowing the input profiles to be customized during emulation is more convenient and user-friendly.

I made this a separate pull request because maybe there was a technical reason for the previous blocking behavior that I'm not aware of and, in that case, would end up making my changes undesirable.